### PR TITLE
GameState Factory

### DIFF
--- a/src/data/spec.ts
+++ b/src/data/spec.ts
@@ -1,0 +1,121 @@
+import { CardID, Color, Spec } from "../framework/types";
+
+export const getSpecStarters = (spec: Spec): Array<CardID> => {
+  return colorStarters[colorMap[spec]];
+};
+
+const colorMap: Record<Spec, Color> = {
+  ANARCHY: "RED",
+  BLOOD: "RED",
+  FIRE: "RED",
+
+  BALANCE: "GREEN",
+  FERAL: "GREEN",
+  GROWTH: "GREEN",
+
+  LAW: "BLUE",
+  PEACE: "BLUE",
+  TRUTH: "BLUE",
+
+  DEMONOLOGY: "BLACK",
+  DISEASE: "BLACK",
+  NECROMANCY: "BLACK",
+
+  DISCIPLINE: "WHITE",
+  NINJUTSU: "WHITE",
+  STRENGTH: "WHITE",
+
+  PAST: "PURPLE",
+  PRESENT: "PURPLE",
+  FUTURE: "PURPLE",
+
+  BASHING: "NEUTRAL",
+  FINESSE: "NEUTRAL",
+};
+
+const colorStarters: Record<Color, Array<CardID>> = {
+  RED: [
+    "Nautical Dog",
+    "Mad Man",
+    "Bombaster",
+    "Careless Musketeer",
+    "Bloodrage Ogre",
+    "Makeshift Rambaster",
+    "Bloodburn",
+    "Scorch",
+    "Charge",
+    "Pillage",
+  ],
+  GREEN: [
+    "Merfolk Prospector",
+    "Tiger Cub",
+    "Young Treant",
+    "Playful Panda",
+    "Ironbark Treant",
+    "Spore Shambler",
+    "Verdant Tree",
+    "Rich Earth",
+    "Rampant Growth",
+    "Forest's Favor",
+  ],
+  BLUE: [
+    "Building Inspector",
+    "Spectral Aven",
+    "Bluecoat Musketeer",
+    "Traffic Director",
+    "Porkhand Magistrate",
+    "Reputable Newsman",
+    "Jail",
+    "Lawful Search",
+    "Arrest",
+    "Manufactured Truth",
+  ],
+  BLACK: [
+    "Pestering Haunt",
+    "Skeleton Javelineer",
+    "Poisonblade Rogue",
+    "Thieving Imp",
+    "Jandra, the Negator",
+    "Graveyard",
+    "Skeletal Archery",
+    "Deteriorate",
+    "Summon Skeletons",
+    "Sacrifice the Weak",
+  ],
+  WHITE: [
+    "Smoker",
+    "Savior Monk",
+    "Fox Viper",
+    "Aged Sensei",
+    "Morningstar Flagbearer",
+    "Fox Primus",
+    "Safe Attacking",
+    "Sensei's Advice",
+    "Grappling Hook",
+    "Snapback",
+  ],
+  PURPLE: [
+    "Neo Plexus",
+    "Plasmodium",
+    "Nullcraft",
+    "Fading Argonaut",
+    "Tinkerer",
+    "Hardened Mox",
+    "Battle Suits",
+    "Time Spiral",
+    "Temporal Research",
+    "Forgotten Fighter",
+  ],
+  NEUTRAL: [
+    "Timely Messenger",
+    "Tenderfoot",
+    "Older Brother",
+    "Brick Thief",
+    "Helpful Turtle",
+    "Granfalloon Flagbearer",
+    "Fruit Ninja",
+    "Spark",
+    "Bloom",
+    "Wither",
+  ],
+};

--- a/src/framework/actions/hand.ts
+++ b/src/framework/actions/hand.ts
@@ -1,6 +1,6 @@
 import { lookupCard } from "../../data";
 
-import { GameState, PlayerState } from "../types";
+import { CardID, GameState, PlayerState } from "../types";
 
 import { makeInstance } from "./helpers";
 
@@ -38,16 +38,24 @@ const shuffle = (P: PlayerState): void => {
     throw new Error("deck is not empty");
   }
 
-  // Shamelessly copied from https://link.medium.com/1JmrvTx7Y7
-  for (let i = P.discard.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * i);
-    const temp = P.discard[i];
-    P.discard[i] = P.discard[j];
-    P.discard[j] = temp;
-  }
+  shuffleCards(P.discard);
 
   P.deck = P.discard;
   P.discard = [];
+};
+
+/**
+ * Shuffles the given set of cards. The array is shuffled in-place.
+ * @param cards
+ */
+export const shuffleCards = (cards: Array<CardID>): void => {
+  // Shamelessly copied from https://link.medium.com/1JmrvTx7Y7
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * i);
+    const temp = cards[i];
+    cards[i] = cards[j];
+    cards[j] = temp;
+  }
 };
 
 /**

--- a/src/framework/actions/turn.ts
+++ b/src/framework/actions/turn.ts
@@ -3,6 +3,18 @@ import { discardAll, drawCard } from "./hand";
 import { MAX_GOLD, MAX_HAND_SIZE, WORKERS_TO_SKIP_TECH } from "../constants";
 import { queryInstances } from "../queries/common";
 
+export const startGame = ($: GameState): void => {
+  const gameStarted = $.round !== 1 ||
+    $.activePlayer !== $.firstPlayer ||
+    $.turnPhase !== "READY";
+
+  if (gameStarted) {
+    throw new Error("game has already started");
+  }
+
+  handleReadyPhase($);
+};
+
 const handleReadyPhase = ($: GameState): void => {
   if ($.turnPhase !== "READY") {
     throw new Error(`not in ready phase (${$.turnPhase})`);

--- a/src/framework/state/gamestate.ts
+++ b/src/framework/state/gamestate.ts
@@ -1,0 +1,92 @@
+import { GameState, PlayerID, PlayerState, Spec } from "../types";
+import { MAX_HAND_SIZE } from "../constants";
+import { shuffleCards } from "../actions/hand";
+import { getSpecStarters } from "../../data/spec";
+
+export type PlayerSetupData = {
+  starterDeckSpec: Spec;
+  otherSpecs: [Spec, Spec];
+};
+
+export const createInitialGameState = (
+  players: Array<PlayerSetupData>
+): GameState => {
+  const playerStates = players.map((player, idx) => {
+    return createPlayer(player, idx === 0);
+  });
+
+  const playerMap: Record<PlayerID, PlayerState> = {};
+  playerStates.forEach((player, idx) => {
+    playerMap[idxToPlayerID(idx)] = player;
+  });
+
+  return <GameState>{
+    firstPlayer: idxToPlayerID(0),
+    round: 1,
+    activePlayer: idxToPlayerID(0),
+    turnPhase: "READY",
+    instances: {},
+    nextID: 100,
+    players: playerMap,
+  };
+};
+
+const createPlayer = (
+  playerData: PlayerSetupData,
+  isFirst: boolean
+): PlayerState => {
+  // One day, we might allow just a single spec
+  const specs: [Spec, Spec, Spec] = [
+    playerData.starterDeckSpec,
+    playerData.otherSpecs[0],
+    playerData.otherSpecs[1],
+  ];
+
+  const startingCards = getSpecStarters(playerData.starterDeckSpec);
+  shuffleCards(startingCards);
+
+  return <PlayerState>{
+    addon: null,
+    base: {
+      damage: 0,
+    },
+    workers: isFirst ? 4 : 5,
+    gold: 0,
+    specs,
+    mainSpec: null,
+    hand: startingCards.slice(0, MAX_HAND_SIZE),
+    discard: [],
+    deck: startingCards.slice(MAX_HAND_SIZE),
+    canSkipTech: false,
+    hasShuffledThisTurn: false,
+    hasBuiltWorkerThisTurn: false,
+    patrol: {
+      squadLeader: null,
+      elite: null,
+      scavenger: null,
+      technician: null,
+      lookout: null,
+    },
+    techBuildings: [
+      {
+        damage: 0,
+        purchased: false,
+        ready: false,
+      },
+      {
+        damage: 0,
+        purchased: false,
+        ready: false,
+      },
+      {
+        damage: 0,
+        purchased: false,
+        ready: false,
+      },
+    ],
+  };
+};
+
+const idxToPlayerID = (idx: number): PlayerID => {
+  return `P${idx + 1}`;
+};

--- a/src/tests/testhelper.ts
+++ b/src/tests/testhelper.ts
@@ -1,65 +1,22 @@
-import { GameState, PlayerState, Spec } from "../framework/types";
+import { GameState } from "../framework/types";
+import { createInitialGameState } from "../framework/state/gamestate";
+import { startGame } from "../framework/actions/turn";
 
 export const P1 = "P1";
 export const P2 = "P2";
 
-export const initDummyGameState: () => GameState = () => {
-  return {
-    firstPlayer: P1,
-    round: 1,
-    activePlayer: P1,
-    turnPhase: "MAIN",
-    instances: {},
-    nextID: 100,
-    players: {
-      [P1]: generatePlayer([ "ANARCHY", "BLOOD", "FIRE" ], true),
-      [P2]: generatePlayer([ "BALANCE", "FERAL", "GROWTH" ]),
+export const initDummyGameState = (): GameState => {
+  const gameState = createInitialGameState([
+    {
+      starterDeckSpec: "ANARCHY",
+      otherSpecs: [ "BLOOD", "FIRE" ],
+    }, {
+      starterDeckSpec: "BALANCE",
+      otherSpecs: [ "FERAL", "GROWTH" ],
     },
-  };
-};
+  ]);
 
-const generatePlayer = (
-  specs: [Spec, Spec, Spec],
-  first = false
-): PlayerState => {
-  return {
-    addon: null,
-    base: {
-      damage: 0,
-    },
-    workers: first ? 4 : 5,
-    gold: 0,
-    specs,
-    mainSpec: null,
-    hand: [],
-    discard: [],
-    deck: [],
-    canSkipTech: false,
-    hasShuffledThisTurn: false,
-    hasBuiltWorkerThisTurn: false,
-    patrol: {
-      squadLeader: null,
-      elite: null,
-      scavenger: null,
-      technician: null,
-      lookout: null,
-    },
-    techBuildings: [
-      {
-        damage: 0,
-        purchased: false,
-        ready: false,
-      },
-      {
-        damage: 0,
-        purchased: false,
-        ready: false,
-      },
-      {
-        damage: 0,
-        purchased: false,
-        ready: false,
-      },
-    ],
-  };
+  startGame(gameState);
+
+  return gameState;
 };


### PR DESCRIPTION
Helpers to initialize game state data, including player hands and decks. Does not initialize heroes or Codexes (Codices? Codii?). Games must be started via startGame().

Tests have all been updated to use a real GameState rather than the dummy version. This means the first player has properly gone through their initial Ready and Upkeep phase and has a real hand and deck (with shuffled cards). This mostly just affected the turn logic unit tests, but may affect others that are not merged currently.

Resolves #19