### PR TITLE
add standard endpoints for generating redacted views

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 make setup
 make build
 ```
+
+## Contributing
+
+[API / Development Docs](src/README.md)

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,5 @@
+# codex lib
+
+## References
+
+[core types](framework/types/serializable/README.md)

--- a/src/framework/accessors/instance.ts
+++ b/src/framework/accessors/instance.ts
@@ -52,15 +52,15 @@ export const canPerformAttack = (
     return false;
   }
 
-  if (getAttribute($, I, "ATTACK") <= 0) {
-    return false;
-  }
-
   if (I.readyState !== "READY") {
     return false;
   }
 
   if (I.arrivalFatigue && !hasTrait($, I, "HASTE")) {
+    return false;
+  }
+
+  if (getAttribute($, I, "ATTACK") <= 0) {
     return false;
   }
 

--- a/src/tests/api/views.ts
+++ b/src/tests/api/views.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+
+import { REDACTED_CARD, getViewForPlayer } from "../..";
+import { GameState, PlayerState } from "../../framework/types";
+
+import {
+  P1,
+  P2,
+  makeDefaultGame,
+} from "../testhelper";
+
+describe("api", () => {
+  describe("getViewForPlayer()", () => {
+    let state: GameState;
+    let ownView: PlayerState;
+    let oppView: PlayerState;
+
+    beforeEach(() => {
+      state = makeDefaultGame().state;
+      for (const pid in state.players) {
+        if (Object.prototype.hasOwnProperty.call(state.players, pid)) {
+          state.players[pid].discard.push("Crash Bomber");
+        }
+      }
+
+      const view = getViewForPlayer(state, P1);
+      ownView = view.players[P1];
+      oppView = view.players[P2];
+    });
+
+    it("doesn't hide own hand", () => {
+      expect(ownView.hand).to.deep.equal(state.players[P1].hand);
+      expect(ownView.hand.includes(REDACTED_CARD)).to.equal(false);
+    });
+
+    it("hides own deck", () => {
+      expect(ownView.deck).not.to.deep.equal(state.players[P1].deck);
+      expect(ownView.deck.includes(REDACTED_CARD)).to.equal(true);
+    });
+
+    it("doesn't hide own discard", () => {
+      expect(ownView.discard).to.deep.equal(state.players[P1].discard);
+      expect(ownView.discard.includes(REDACTED_CARD)).to.equal(false);
+    });
+
+    it("doesn't hide own codex", () => {
+      expect(ownView.codex).to.deep.equal(state.players[P1].codex);
+      expect(
+        Object.keys(ownView.codex).includes(REDACTED_CARD),
+      ).to.equal(false);
+    });
+
+    it("hides others' hands", () => {
+      expect(oppView.hand).not.to.deep.equal(state.players[P2].hand);
+      expect(oppView.hand.includes(REDACTED_CARD)).to.equal(true);
+    });
+
+    it("hides others' decks", () => {
+      expect(oppView.deck).not.to.deep.equal(state.players[P2].deck);
+      expect(oppView.deck.includes(REDACTED_CARD)).to.equal(true);
+    });
+
+    it("hides others' discards", () => {
+      expect(oppView.discard).not.to.deep.equal(state.players[P2].discard);
+      expect(oppView.discard.includes(REDACTED_CARD)).to.equal(true);
+    });
+
+    it("hides others' codices", () => {
+      expect(oppView.codex).not.to.deep.equal(state.players[P2].codex);
+      expect(oppView.codex[REDACTED_CARD]).to.equal(72);
+      expect(Object.keys(oppView.codex)).to.deep.equal([ REDACTED_CARD ]);
+    });
+  });
+});


### PR DESCRIPTION
Adds a third function to the external interface, for generating views from player POVs.

Some other minor changes:
- Adds links to readme's to type docs
- Reorders checks in `canPerformAttack` to be slightly more efficient, by checking the cheapest conditions first
- Fixes a bug where hero cards were included in the codex
- Tweaks initial value for `nextID` so that players and instances/effects never share numerical slots, while ensuring that players have the earliest IDs for simplicity of use (i.e., we should have P1, P2, P3, P4); in practice this just means that player's bases don't share their same numerical ID