### PR TITLE
red starter cards and effect chaining

### DIFF
--- a/src/data/helpers.ts
+++ b/src/data/helpers.ts
@@ -1,9 +1,16 @@
 import {
   AbilityFn,
+  ActivatedAbility,
+  ActivatedAbilityCost,
+  ActivatedAbilityFn,
+  CardID,
   ConstantParam,
   EffectParamQuery,
   EffectParamValue,
   InstanceCard,
+  InstanceID,
+  InstanceState,
+  ResolvableEffect,
   TriggerEvent,
   TriggeredAbility,
   TriggeredAbilityFn,
@@ -65,6 +72,31 @@ export const getProperties = (
 
   return properties;
 };
+
+export const active = (
+  cid: CardID,
+  index: number,
+  cost: Array<ActivatedAbilityCost>,
+  effect: ActivatedAbilityFn,
+): ActivatedAbility => ({
+  id: `${cid} #${index}`,
+  cost,
+  effect,
+});
+
+export const effectBase = <TypeT extends ResolvableEffect["type"]>(
+  cid: CardID,
+  I: InstanceState | null,
+  type: TypeT,
+): {
+  type: TypeT,
+  sourceCard: CardID,
+  sourceInstance: InstanceID | null,
+} => ({
+    type,
+    sourceCard: cid,
+    sourceInstance: I?.id ?? null,
+  });
 
 export const trigger = <TypeT extends TriggerEvent["type"]>(
   type: TypeT,

--- a/src/data/helpers.ts
+++ b/src/data/helpers.ts
@@ -5,6 +5,7 @@ import {
   ActivatedAbilityFn,
   CardID,
   ConstantParam,
+  EffectParamInherited,
   EffectParamQuery,
   EffectParamValue,
   InstanceCard,
@@ -21,6 +22,18 @@ export const constantParam = <T> (
 ): ConstantParam<T> => ({
     type: "CONSTANT",
     value,
+  });
+
+export const inheritParam = <TypeT> (
+  type: TypeT,
+  field: EffectParamInherited["inherit"]["field"],
+  mode: EffectParamInherited["inherit"]["mode"] = "DIRECT",
+): { type: TypeT } & EffectParamInherited => ({
+    type,
+    inherit: {
+      field,
+      mode,
+    },
   });
 
 export const queryParam = <TypeT, QueryT> (
@@ -83,6 +96,13 @@ export const active = (
   cost,
   effect,
 });
+
+export const constantModifiers = (
+  modifiers: (ResolvableEffect & { type: "MODIFY" })["modifiers"]["value"],
+): (
+  ResolvableEffect & { type: "MODIFY" }
+)["modifiers"] =>
+  constantParam(modifiers);
 
 export const effectBase = <TypeT extends ResolvableEffect["type"]>(
   cid: CardID,

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -2,11 +2,19 @@ import {
   AttachmentSpellCard,
   InstanceCard,
   InstantSpellCard,
+  ModifierGrant,
   OngoingSpellCard,
 } from "../framework/types";
 
 import { REQUIRE_ALL_CARD_PROPERTIES } from "./config";
-import { constantParam, queryParam, trigger, valueParam } from "./helpers";
+import { BASE_CARD } from "./core";
+import {
+  constantParam,
+  effectBase,
+  queryParam,
+  trigger,
+  valueParam,
+} from "./helpers";
 
 const spellBoostCosts: Record<string, number | undefined> = {
   // such empty
@@ -24,13 +32,58 @@ export const getSpellDetails = (
   | SpellDetails<InstantSpellCard>
   | SpellDetails<OngoingSpellCard> => {
   switch (id) {
+  case "Charge":
+    return instantSpell({
+      effect: (_, P) => [
+        {
+          ...effectBase(id, null, "MODIFY"),
+          target: queryParam("INSTANCE", {
+            player: P.id,
+            type: "UNIT",
+          }),
+          modifiers: constantParam([
+            {
+              expiration: "END_OF_TURN",
+              sourceCard: id,
+              effect: {
+                type: "ATTRIBUTE",
+                trait: "ATTACK",
+                amount: 1,
+              },
+            },
+            {
+              expiration: "END_OF_TURN",
+              sourceCard: id,
+              effect: {
+                type: "TRAIT",
+                trait: "HASTE",
+              },
+            },
+            // TODO clean this up, make some modifier helpers
+          ] as Array<ModifierGrant & { expiration: "END_OF_TURN" }>),
+        },
+      ],
+    });
+  case "Pillage":
+    return instantSpell({
+      // TODO can't use a custom trigger because there's no instance...
+      // there may be some way to do this by adding a trigger to the target base...
+      // in general it feels like we just need a way to use the same params for multiple effects
+      // this shouldn't be hard, just add an optional field for "chained" effects, and a new param source "previous"
+      effect: () => [
+        {
+          ...effectBase(id, null, "PILLAGE"),
+          target: queryParam("INSTANCE", {
+            card: BASE_CARD.id,
+          }),
+        },
+      ],
+    });
   case "Scorch":
     return instantSpell({
       effect: () => [
         {
-          type: "DAMAGE",
-          sourceCard: id,
-          sourceInstance: null,
+          ...effectBase(id, null, "DAMAGE"),
           target: queryParam("INSTANCE", {
             OR: [
               { patrolling: true },

--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -3,6 +3,7 @@ import { ResolvableEffect } from "../framework/types";
 import { REQUIRE_ALL_CARD_PROPERTIES } from "./config";
 import {
   active,
+  constantModifiers,
   constantParam,
   effectBase,
   getProperties,
@@ -116,7 +117,7 @@ export const getUnitProperties = getProperties(id => {
             {
               ...effectBase(id, I, "MODIFY"),
               target: valueParam("INSTANCE", I.id),
-              modifiers: constantParam([
+              modifiers: constantModifiers([
                 {
                   expiration: "END_OF_COMBAT",
                   sourceCard: I.card,

--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -1,6 +1,14 @@
+import { ResolvableEffect } from "../framework/types";
+
 import { REQUIRE_ALL_CARD_PROPERTIES } from "./config";
 import {
+  active,
+  constantParam,
+  effectBase,
   getProperties,
+  queryParam,
+  trigger,
+  valueParam,
 } from "./helpers";
 
 const unitBoostCosts: Record<string, number | undefined> = {
@@ -14,17 +22,124 @@ export const getUnitBoostCost = (
 };
 
 export const getUnitProperties = getProperties(id => {
+  let aid = 1;
   switch (id) {
+  case "Bloodrage Ogre":
+    return {
+      triggeredAbilities: [
+        trigger("END_OF_TURN", ($, I) => {
+          if ($.state.activePlayer !== I.controller) {
+            return [];
+          }
+          if (I.arrivalFatigue) {
+            return [];
+          }
+          if (I.memory.attackedThisTurn === "true") {
+            return [];
+          }
+          return [
+            {
+              ...effectBase(id, I, "BOUNCE_TO_HAND"),
+              target: valueParam("INSTANCE", I.id),
+            },
+          ];
+        }),
+        trigger("THIS_ATTACKS", (_, I) => {
+          I.memory.attackedThisTurn = "true";
+          return [];
+        }),
+        trigger("UPKEEP", (_, I) => {
+          I.memory.attackedThisTurn = "false";
+          return [];
+        }),
+      ],
+    };
+  case "Bombaster":
+    return {
+      activatedAbilities: [
+        active(id, aid++, [
+          { type: "GOLD", amount: 1 },
+          { type: "SACRIFICE_THIS" },
+        ], (_, I) => [
+          {
+            ...effectBase(id, I, "DAMAGE"),
+            target: queryParam("INSTANCE", {
+              patrolling: true,
+              type: "UNIT",
+            }),
+            amount: constantParam(2),
+          },
+        ]),
+      ],
+    };
+  case "Careless Musketeer":
+    return {
+      activatedAbilities: [
+        active(id, aid++, [ { type: "EXHAUST_THIS" } ], ($, I) => {
+          const effects: Array<ResolvableEffect> = [
+            {
+              ...effectBase(id, I, "DAMAGE"),
+              target: queryParam("INSTANCE", {
+                type: [ "BUILDING", "UNIT" ],
+              }),
+              amount: constantParam(1),
+            },
+          ];
+
+          const base = $.getPlayer(I.controller)?.base;
+          if (base != null) {
+            effects.push({
+              ...effectBase(id, I, "DAMAGE"),
+              target: valueParam("INSTANCE", base),
+              amount: constantParam(1),
+            });
+          }
+
+          return effects;
+        }),
+      ],
+    };
   case "Mad Man":
     return {
       traits: [ "HASTE" ],
     };
-  case "Bloodrage Ogre":
+  case "Makeshift Rambaster":
+    return {
+      traits: [ "HASTE", "NO_PATROL" ],
+      triggeredAbilities: [
+        trigger("THIS_ATTACKS", ($, I, e) => {
+          const targetCard = $.data.lookupCard(e.instance.card);
+          if (targetCard.type !== "BUILDING") {
+            return [];
+          }
+          return [
+            {
+              ...effectBase(id, I, "MODIFY"),
+              target: valueParam("INSTANCE", I.id),
+              modifiers: constantParam([
+                {
+                  expiration: "END_OF_COMBAT",
+                  sourceCard: I.card,
+                  effect: {
+                    type: "ATTRIBUTE",
+                    attribute: "ATTACK",
+                    amount: 2,
+                  },
+                },
+              ]),
+            },
+          ];
+        }),
+      ],
+    };
+  case "Nautical Dog":
+    return {
+      attributes: { FRENZY: 1 },
+    };
   case "Calypso Vystari":
   case "Chameleon":
   case "Disguised Monkey":
   case "Gemscout Owl":
-  case "Nautical Dog":
   case "Pirate Gunship":
   case "Tyrannosaurus Rex":
     // WIP

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -1,8 +1,42 @@
 import { REQUIRE_ALL_CARD_PROPERTIES } from "./config";
-import { getProperties } from "./helpers";
+import {
+  active,
+  constantParam,
+  effectBase,
+  getProperties,
+  queryParam,
+  trigger,
+} from "./helpers";
 
 export const getUpgradeProperties = getProperties(id => {
+  let aid = 1;
   switch (id) {
+  case "Bloodburn":
+    return {
+      activatedAbilities: [
+        active(id, aid++, [
+          { type: "EXHAUST_THIS" },
+          { type: "CUSTOM_RUNES", rune: "BLOOD", amount: 2 },
+        ], (_, I) => [
+          {
+            ...effectBase(id, I, "DAMAGE"),
+            target: queryParam("INSTANCE", {
+              type: [ "BUILDING", "UNIT" ],
+            }),
+            amount: constantParam(1),
+          },
+        ]),
+      ],
+      triggeredAbilities: [
+        trigger("INSTANCE_DIES", ($, I, e) => {
+          const targetCard = $.data.lookupCard(e.instance.card);
+          if (targetCard.type === "UNIT") {
+            I.customRunes.BLOOD = Math.min((I.customRunes.BLOOD ?? 0) + 1, 4);
+          }
+          return [];
+        }),
+      ],
+    };
   default:
     if (REQUIRE_ALL_CARD_PROPERTIES) {
       throw new Error(`Failed to find properties for upgrade "${id}"`);

--- a/src/framework/accessors/player.ts
+++ b/src/framework/accessors/player.ts
@@ -1,6 +1,15 @@
 import { PATROL_SLOTS } from "../constants";
 import { GameEngine } from "../engine";
-import { PlayerState } from "../types";
+import { PatrolSlot, PlayerState } from "../types";
+
+export const getEmptyPatrolSlots = (
+  P: PlayerState | null,
+): Array<PatrolSlot> => {
+  if (P == null) {
+    return [];
+  }
+  return PATROL_SLOTS.filter(slot => P.patrol[slot] == null);
+};
 
 export const getHeroLimit = (
   $: GameEngine,
@@ -40,15 +49,17 @@ export function *getOpponents(
 export const hasEmptyPatrolSlot = (
   P: PlayerState | null,
 ): boolean => {
-  if (P == null) {
-    return false;
+  return getFirstEmptyPatrolSlot(P) != null;
+};
+
+const getFirstEmptyPatrolSlot = (
+  P: PlayerState | null,
+): PatrolSlot | null => {
+  // eslint-disable-next-line no-unreachable-loop
+  for (const slot of getEmptyPatrolSlots(P)) {
+    return slot;
   }
-  for (const slot of PATROL_SLOTS) {
-    if (P.patrol[slot] == null) {
-      return true;
-    }
-  }
-  return false;
+  return null;
 };
 
 const hasUsableTechBuilding = (

--- a/src/framework/accessors/player.ts
+++ b/src/framework/accessors/player.ts
@@ -55,11 +55,7 @@ export const hasEmptyPatrolSlot = (
 const getFirstEmptyPatrolSlot = (
   P: PlayerState | null,
 ): PatrolSlot | null => {
-  // eslint-disable-next-line no-unreachable-loop
-  for (const slot of getEmptyPatrolSlots(P)) {
-    return slot;
-  }
-  return null;
+  return getEmptyPatrolSlots(P).find(() => true) || null;
 };
 
 const hasUsableTechBuilding = (

--- a/src/framework/types/serializable/resolvable.ts
+++ b/src/framework/types/serializable/resolvable.ts
@@ -15,6 +15,7 @@ export type ResolvableEffect = {
     | "DISCARD"
     | "DRAW"
     | "GIVE_GOLD"
+    | "STEAL_GOLD"
     ;
   player: PlayerParam;
   amount: ConstantParam<number>;
@@ -27,6 +28,7 @@ export type ResolvableEffect = {
     | "ARRIVE"
     | "BOUNCE_TO_HAND"
     | "DESTROY"
+    | "PILLAGE"
     | "SIDELINE"
     | "TAKE_CONTROL"
     | "TRASH"
@@ -36,7 +38,6 @@ export type ResolvableEffect = {
   type:
     | "DAMAGE"
     | "GIVE_LEVELS"
-    | "STEAL_GOLD"
     ;
   target: InstanceParam;
   amount: ConstantParam<number>;

--- a/src/framework/types/serializable/resolvable.ts
+++ b/src/framework/types/serializable/resolvable.ts
@@ -7,9 +7,13 @@ import { InstanceQuery } from "./query";
 
 export type ResolvableEffectID = string;
 
-export type ResolvableEffect = {
+export type ResolvableEffect = ResolvableEffectWithoutSource & {
   sourceCard: CardID | null;
   sourceInstance: InstanceID | null;
+};
+
+export type ResolvableEffectWithoutSource = {
+  chainedEffects?: Array<ResolvableEffectWithoutSource>;
 } & ({
   type:
     | "DISCARD"
@@ -28,7 +32,6 @@ export type ResolvableEffect = {
     | "ARRIVE"
     | "BOUNCE_TO_HAND"
     | "DESTROY"
-    | "PILLAGE"
     | "SIDELINE"
     | "TAKE_CONTROL"
     | "TRASH"
@@ -48,12 +51,12 @@ export type ResolvableEffect = {
     expiration: Exclude<ModifierGrant["expiration"], "CONTINUOUS">,
   }>>;
 } | {
-  type: "SHOVE";
+  type: "MOVE_TO_SLOT";
   target: InstanceParam;
   slot: PatrolSlotParam;
 } | {
   type: "CUSTOM";
-  sourceInstance: InstanceID;
+  target: InstanceParam;
   trigger: ConstantParam<CustomTriggerID>;
   params: Record<string, EffectParam>;
 });
@@ -64,6 +67,16 @@ export type EffectParam =
   | PatrolSlotParam
   | PlayerParam
   ;
+
+export interface EffectParamInherited {
+  inherit: {
+    field: string;
+    mode:
+      | "DIRECT"
+      | "GET_CONTROLLER"
+      ;
+  };
+}
 
 export interface EffectParamQuery<T> {
   query: T;
@@ -80,7 +93,7 @@ export interface EffectParamValue<T> {
 type CommonEffectParam<TypeT, ValueT, QueryT> = {
   type: TypeT;
 } & (
-  EffectParamValue<ValueT> | EffectParamQuery<QueryT>
+  EffectParamValue<ValueT> | EffectParamQuery<QueryT> | EffectParamInherited
 );
 
 export interface ConstantParam<T> extends EffectParamValue<T> {
@@ -91,7 +104,7 @@ export type InstanceParam =
   CommonEffectParam<"INSTANCE", InstanceID, InstanceQuery>;
 
 export type PatrolSlotParam =
-  CommonEffectParam<"PATROL_SLOT", PatrolSlot, unknown>;
+  CommonEffectParam<"PATROL_SLOT", PatrolSlot, Array<PatrolSlot>>;
 
 export type PlayerParam =
-  CommonEffectParam<"PLAYER", PlayerID, unknown>;
+  CommonEffectParam<"PLAYER", PlayerID, Array<PlayerID>>;

--- a/src/game/effects.ts
+++ b/src/game/effects.ts
@@ -1,4 +1,3 @@
-import { getPatrolSlot, hasEmptyPatrolSlot } from "../framework/accessors";
 import { PATROL_SLOTS } from "../framework/constants";
 import { GameEngine } from "../framework/engine";
 import {
@@ -14,6 +13,7 @@ import {
 } from "../framework/mutators";
 import {
   EffectParam,
+  EffectParamInherited,
   EffectParamQuery,
   EffectParamValue,
   InstanceID,
@@ -33,6 +33,7 @@ const GLOBAL_EFFECT_KEYS = [
   "sourceInstance",
   "type",
   "params",
+  "chainedEffects",
 ];
 
 export const effectParamsAreValid = (
@@ -55,7 +56,7 @@ export const validateEffectParams = (
       }
 
       const fromEffect = effectAsMap[key];
-      if (isQueryParam(fromEffect)) {
+      if (isQueryParam<unknown>(fromEffect)) {
         // valid if:
         // - the param exists and matches the query
         // - the param doesn't exist and the query has only one option
@@ -71,25 +72,6 @@ export const validateEffectParams = (
     }
   }
 
-  switch (effect.type) {
-  case "SHOVE": {
-    const I = resolveInstanceParam($, effect, params, "target");
-    const slot = resolvePatrolSlotParam(effect, params, "slot");
-    const P = $.getPlayer(I?.controller ?? null);
-    if (I == null || slot == null || P == null) {
-      throw new Error("panic: bad shove didn't fail early validation");
-    }
-    if (getPatrolSlot($, I) === slot) {
-      if (hasEmptyPatrolSlot(P)) {
-        return "must shove target to empty slot";
-      }
-    } else if (P.patrol[slot] != null) {
-      return "destination slot is not empty";
-    }
-    break;
-  }
-  }
-
   return null;
 };
 
@@ -98,9 +80,18 @@ export const executeEffect = (
   effect: ResolvableEffect,
   params: Record<string, string>,
 ): void => {
+  executeEffectWithInheritedParams($, effect, params, {});
+};
+
+const executeEffectWithInheritedParams = (
+  $: GameEngine,
+  effect: ResolvableEffect,
+  params: Record<string, string>,
+  inherited: Record<string, string>,
+): void => {
   switch (effect.type) {
   case "BOUNCE_TO_HAND": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       returnInstanceToHand($, I);
     }
@@ -118,21 +109,26 @@ export const executeEffect = (
     break;
   }
   case "DAMAGE": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
-      dealDamage($, I, effect.amount.value, null);
+      dealDamage(
+        $,
+        I,
+        effect.amount.value,
+        $.getInstance(effect.sourceInstance),
+      );
     }
     break;
   }
   case "DESTROY": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       destroy($, I, $.getInstance(effect.sourceInstance));
     }
     break;
   }
   case "DISCARD": {
-    const P = resolvePlayerParam($, effect, params, "player");
+    const P = resolvePlayerParam($, effect, params, inherited, "player");
     if (P != null) {
       if (effect.amount.value >= P.hand.length) {
         P.discard.push(...P.hand);
@@ -148,7 +144,7 @@ export const executeEffect = (
     break;
   }
   case "DISCARD_SELECTED": {
-    const P = resolvePlayerParam($, effect, params, "player");
+    const P = resolvePlayerParam($, effect, params, inherited, "player");
     if (P != null && P.hand.includes(effect.card.value)) {
       removeCardFromHand(P, effect.card.value);
       P.discard.push(effect.card.value);
@@ -156,7 +152,7 @@ export const executeEffect = (
     break;
   }
   case "DRAW": {
-    const P = resolvePlayerParam($, effect, params, "player");
+    const P = resolvePlayerParam($, effect, params, inherited, "player");
     if (P != null) {
       for (let i = 0; i < effect.amount.value; i++) {
         if (P.deck.length === 0) {
@@ -179,72 +175,45 @@ export const executeEffect = (
     break;
   }
   case "GIVE_GOLD": {
-    const P = resolvePlayerParam($, effect, params, "player");
+    const P = resolvePlayerParam($, effect, params, inherited, "player");
     if (P != null) {
       giveGold(P, effect.amount.value);
     }
     break;
   }
   case "GIVE_LEVELS": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       giveLevels($, I, effect.amount.value);
     }
     break;
   }
   case "MODIFY": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       I.modifiers.push(...effect.modifiers.value);
     }
     break;
   }
-  case "PILLAGE": {
-    const I = resolveInstanceParam($, effect, params, "target");
-    if (I != null) {
-      dealDamage($, I, 1, null);
-
-      const hasPirate = $.findInstance({
-        player: $.state.activePlayer,
-        tags: [ "PIRATE" ],
-      }) != null;
-
-      executeEffect($, {
-        type: "STEAL_GOLD",
-        sourceCard: effect.sourceCard,
-        sourceInstance: effect.sourceInstance,
-        player: {
-          type: "PLAYER",
-          value: I.controller,
-        },
-        amount: {
-          type: "CONSTANT",
-          value: hasPirate ? 2 : 1,
-        },
-      }, {});
-    }
-    break;
-  }
-  case "SHOVE": {
-    const I = resolveInstanceParam($, effect, params, "target");
-    const slot = resolvePatrolSlotParam(effect, params, "slot");
+  case "MOVE_TO_SLOT": {
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
+    const slot = resolvePatrolSlotParam(effect, params, inherited, "slot");
     const P = $.getPlayer(I?.controller ?? null);
     if (I != null && slot != null && P != null) {
       sideline($, I);
       P.patrol[slot] = I.id;
-      dealDamage($, I, 1, $.getInstance(effect.sourceInstance));
     }
     break;
   }
   case "SIDELINE": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       sideline($, I);
     }
     break;
   }
   case "STEAL_GOLD": {
-    const targetP = resolvePlayerParam($, effect, params, "player");
+    const targetP = resolvePlayerParam($, effect, params, inherited, "player");
     const activeP = $.getPlayer($.state.activePlayer);
     if (targetP != null && activeP != null && activeP !== targetP) {
       const amount = Math.min(effect.amount.value, targetP.gold);
@@ -254,14 +223,14 @@ export const executeEffect = (
     break;
   }
   case "TAKE_CONTROL": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       I.controller = $.state.activePlayer;
     }
     break;
   }
   case "TRASH": {
-    const I = resolveInstanceParam($, effect, params, "target");
+    const I = resolveInstanceParam($, effect, params, inherited, "target");
     if (I != null) {
       trash($, I);
     }
@@ -269,6 +238,34 @@ export const executeEffect = (
   }
   default:
     throw new Error(`unrecognized effect type "${effect.type}"`);
+  }
+
+  if (effect.chainedEffects != null) {
+    const inheritableParams = {
+      ...inherited,
+    };
+    for (const key in effect) {
+      if (Object.prototype.hasOwnProperty.call(effect, key)) {
+        if (!GLOBAL_EFFECT_KEYS.includes(key)) {
+          const fromEffect =
+            (effect as unknown as Record<string, EffectParam>)[key];
+
+          if (isValueParam(fromEffect)) {
+            inheritableParams[key] = fromEffect.value as string;
+          } else if (isQueryParam<unknown>(fromEffect)) {
+            inheritableParams[key] = params[key];
+          }
+        }
+      }
+    }
+
+    for (const chainedEffect of effect.chainedEffects) {
+      executeEffectWithInheritedParams($, {
+        ...chainedEffect,
+        sourceCard: effect.sourceCard,
+        sourceInstance: effect.sourceInstance,
+      }, params, inheritableParams);
+    }
   }
 };
 
@@ -285,7 +282,7 @@ export const shouldCancelEffect = (
       }
 
       const fromEffect = effectAsMap[key];
-      if (isQueryParam(fromEffect)) {
+      if (isQueryParam<unknown>(fromEffect)) {
         if (getPossibleQueryTargets($, fromEffect).length === 0) {
           return true;
         }
@@ -308,9 +305,21 @@ const resolveInstanceParam = <Key extends string> (
   $: GameEngine,
   effect: Record<Key, InstanceParam>,
   params: Record<Key, InstanceID | null>,
+  inherited: Record<string, string>,
   key: Key,
 ): InstanceState | null => {
   const fromEffect = effect[key];
+
+  if (isInheritedParam(fromEffect)) {
+    const raw = inherited[fromEffect.inherit.field];
+    switch (fromEffect.inherit.mode) {
+    case "DIRECT":
+      return $.getInstance(raw);
+    default:
+      throw new Error("unsupported inherit mode for instance param");
+    }
+  }
+
   if (isValueParam(fromEffect)) {
     return $.getInstance(fromEffect.value);
   }
@@ -329,9 +338,26 @@ const resolveInstanceParam = <Key extends string> (
 const resolvePatrolSlotParam = <Key extends string> (
   effect: Record<Key, PatrolSlotParam>,
   params: Record<Key, string | null>,
+  inherited: Record<string, string>,
   key: Key,
 ): PatrolSlot | null => {
   const fromEffect = effect[key];
+
+  if (isInheritedParam(fromEffect)) {
+    const raw = inherited[fromEffect.inherit.field];
+    switch (fromEffect.inherit.mode) {
+    case "DIRECT": {
+      const slot = raw as PatrolSlot;
+      if (PATROL_SLOTS.includes(slot)) {
+        return slot;
+      }
+      return null;
+    }
+    default:
+      throw new Error("unsupported inherit mode for patrol slot param");
+    }
+  }
+
   if (isValueParam(fromEffect)) {
     return fromEffect.value;
   }
@@ -350,9 +376,23 @@ const resolvePlayerParam = <Key extends string> (
   $: GameEngine,
   effect: Record<Key, PlayerParam>,
   params: Record<Key, PlayerID | null>,
+  inherited: Record<string, string>,
   key: Key,
 ): PlayerState | null => {
   const fromEffect = effect[key];
+
+  if (isInheritedParam(fromEffect)) {
+    const raw = inherited[fromEffect.inherit.field];
+    switch (fromEffect.inherit.mode) {
+    case "DIRECT":
+      return $.getPlayer(raw);
+    case "GET_CONTROLLER":
+      return $.getPlayer($.getInstance(raw)?.controller ?? null);
+    default:
+      throw new Error("unsupported inherit mode for player param");
+    }
+  }
+
   if (isValueParam(fromEffect)) {
     return $.getPlayer(fromEffect.value);
   }
@@ -368,33 +408,50 @@ const getPossibleQueryTargets = (
   $: GameEngine,
   param: EffectParam,
 ): Array<unknown> => {
-  if (!isQueryParam(param)) {
-    throw new Error("panic: this isn't a query param");
-  }
-
   switch (param.type) {
   case "INSTANCE": {
+    if (!isQueryParam(param)) {
+      throw new Error("panic: this isn't a query param");
+    }
     return Array.from(
       $.queryInstances(param.query),
     ).map(I => I.id);
   }
   case "PATROL_SLOT":
-    return PATROL_SLOTS;
+    if (!isQueryParam(param)) {
+      throw new Error("panic: this isn't a query param");
+    }
+    return param.query;
   case "PLAYER":
-    throw new Error("player queries are not yet supported");
+    if (!isQueryParam(param)) {
+      throw new Error("panic: this isn't a query param");
+    }
+    return param.query;
   default:
     throw new Error("unrecognized queryable effect param type");
   }
 };
 
+const isInheritedParam = (
+  param: EffectParamInherited
+    | EffectParamQuery<unknown>
+    | EffectParamValue<unknown>,
+): param is EffectParamInherited => {
+  return "inherit" in param;
+};
+
 const isQueryParam = <QueryT> (
-  param: EffectParamQuery<QueryT> | EffectParamValue<unknown>,
+  param: EffectParamQuery<QueryT>
+    | EffectParamValue<unknown>
+    | EffectParamInherited,
 ): param is EffectParamQuery<QueryT> => {
   return "query" in param;
 };
 
 const isValueParam = <ValueT> (
-  param: EffectParamValue<ValueT> | EffectParamQuery<unknown>,
+  param: EffectParamValue<ValueT>
+  | EffectParamQuery<unknown>
+  | EffectParamInherited,
 ): param is EffectParamValue<ValueT> => {
   return "value" in param;
 };

--- a/src/game/effects.ts
+++ b/src/game/effects.ts
@@ -199,6 +199,32 @@ export const executeEffect = (
     }
     break;
   }
+  case "PILLAGE": {
+    const I = resolveInstanceParam($, effect, params, "target");
+    if (I != null) {
+      dealDamage($, I, 1, null);
+
+      const hasPirate = $.findInstance({
+        player: $.state.activePlayer,
+        tags: [ "PIRATE" ],
+      }) != null;
+
+      executeEffect($, {
+        type: "STEAL_GOLD",
+        sourceCard: effect.sourceCard,
+        sourceInstance: effect.sourceInstance,
+        player: {
+          type: "PLAYER",
+          value: I.controller,
+        },
+        amount: {
+          type: "CONSTANT",
+          value: hasPirate ? 2 : 1,
+        },
+      }, {});
+    }
+    break;
+  }
   case "SHOVE": {
     const I = resolveInstanceParam($, effect, params, "target");
     const slot = resolvePatrolSlotParam(effect, params, "slot");
@@ -218,8 +244,7 @@ export const executeEffect = (
     break;
   }
   case "STEAL_GOLD": {
-    const I = resolveInstanceParam($, effect, params, "target");
-    const targetP = $.getPlayer(I?.controller ?? null);
+    const targetP = resolvePlayerParam($, effect, params, "player");
     const activeP = $.getPlayer($.state.activePlayer);
     if (targetP != null && activeP != null && activeP !== targetP) {
       const amount = Math.min(effect.amount.value, targetP.gold);

--- a/src/tests/heroes/zane.ts
+++ b/src/tests/heroes/zane.ts
@@ -64,20 +64,19 @@ describe("heroes", () => {
 
     describe("max band", () => {
       let patroller: InstanceState;
-      let effectID: string;
 
       beforeEach(() => {
         patroller =
           createInstance($, oppP, $.data.lookupCard("Bloodrage Ogre"));
         oppP.patrol.SQUAD_LEADER = patroller.id;
-
-        giveLevels($, zane, 5);
-
-        expect($.state.unresolvedEffects.length).to.equal(1);
-        effectID = $.state.unresolvedEffects[0].id;
       });
 
       it("moves a patroller to an empty space", () => {
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         expect(oppP.patrol.SQUAD_LEADER).to.equal(patroller.id);
 
         debugAction($, {
@@ -94,6 +93,11 @@ describe("heroes", () => {
       });
 
       it("deals 1 damage", () => {
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         expect(patroller.damage).to.equal(0);
 
         debugAction($, {
@@ -109,6 +113,11 @@ describe("heroes", () => {
       });
 
       it("can't leave the patroller in place", () => {
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         expect(() => debugAction($, {
           type: "RESOLVE_EFFECT",
           effect: effectID,
@@ -116,24 +125,34 @@ describe("heroes", () => {
             target: patroller.id,
             slot: "SQUAD_LEADER",
           },
-        })).to.throw("must shove target to empty slot");
+        })).to.throw("invalid params for effect: invalid param [slot]");
       });
 
       it("can't move a patroller into an occupied slot", () => {
         oppP.patrol.ELITE =
           createInstance($, oppP, $.data.lookupCard("Nautical Dog")).id;
 
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         expect(() => debugAction($, {
           type: "RESOLVE_EFFECT",
           effect: effectID,
           params: {
             target: patroller.id,
-            slot: "SQUAD_LEADER",
+            slot: "ELITE",
           },
-        })).to.throw("must shove target to empty slot");
+        })).to.throw("invalid params for effect: invalid param [slot]");
       });
 
       it("triggers Zane's midband if it kills the target", () => {
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         patroller.damage = 1;
 
         expect(P.gold).to.equal(4);
@@ -156,6 +175,11 @@ describe("heroes", () => {
         oppP.patrol.SQUAD_LEADER = null;
         oppP.patrol.LOOKOUT = patroller.id;
 
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
+
         expect(P.gold).to.equal(4);
 
         debugAction($, {
@@ -173,8 +197,8 @@ describe("heroes", () => {
       it("can't be used if there are no patrollers", () => {
         oppP.patrol.SQUAD_LEADER = null;
 
+        giveLevels($, zane, 5);
         debugValidateEffects($);
-
         expect($.state.unresolvedEffects.length).to.equal(0);
       });
 
@@ -191,6 +215,11 @@ describe("heroes", () => {
 
         expect(patroller.damage).to.equal(0);
         expect(oppP.patrol.SQUAD_LEADER).to.equal(patroller.id);
+
+        giveLevels($, zane, 5);
+        debugValidateEffects($);
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const effectID = $.state.unresolvedEffects[0].id;
 
         debugAction($, {
           type: "RESOLVE_EFFECT",
@@ -211,8 +240,8 @@ describe("heroes", () => {
         oppP.patrol.LOOKOUT = patroller.id;
         P.gold = 0;
 
+        giveLevels($, zane, 5);
         debugValidateEffects($);
-
         expect($.state.unresolvedEffects.length).to.equal(0);
       });
     });

--- a/src/tests/spells/red.ts
+++ b/src/tests/spells/red.ts
@@ -1,0 +1,7 @@
+describe("spells", () => {
+  describe("red", () => {
+    describe("Pillage", () => {
+      it.skip("can't steal more gold than the target has");
+    });
+  });
+});

--- a/src/tests/spells/red.ts
+++ b/src/tests/spells/red.ts
@@ -1,7 +1,11 @@
+import { expect } from "chai";
+
 describe("spells", () => {
   describe("red", () => {
     describe("Pillage", () => {
-      it.skip("can't steal more gold than the target has");
+      it("can't steal more gold than the target has", () => {
+        expect(true).to.equal(false);
+      });
     });
   });
 });

--- a/src/tests/spells/red.ts
+++ b/src/tests/spells/red.ts
@@ -1,10 +1,93 @@
 import { expect } from "chai";
 
+import { BASE_CARD } from "../../data/core";
+import { GameEngine } from "../../framework/engine";
+import { createInstance } from "../../framework/mutators";
+import { PlayerID, PlayerState } from "../../framework/types";
+import { requireActivePlayer } from "../../game/helpers";
+
+import {
+  P2,
+  debugAction,
+  debugPlayCard,
+  makeDefaultGame,
+} from "../testhelper";
+
 describe("spells", () => {
   describe("red", () => {
+    let $: GameEngine;
+    let P: PlayerState;
+    let oppP: PlayerState;
+
+    beforeEach(() => {
+      $ = makeDefaultGame();
+      P = requireActivePlayer($);
+      oppP = $.state.players[P2];
+    });
+
     describe("Pillage", () => {
+      beforeEach(() => {
+        const EX_RED_HERO = $.data.lookupCard("Captain Zane");
+        createInstance($, P, EX_RED_HERO);
+      });
+
+      const playAndResolvePillage = (
+        targetPlayer: PlayerID,
+      ): void => {
+        debugPlayCard($, "Pillage");
+        expect($.state.unresolvedEffects.length).to.equal(1);
+        const eid = $.state.unresolvedEffects[0].id;
+
+        const base = $.findInstance({
+          card: BASE_CARD.id,
+          player: targetPlayer,
+        });
+        if (base == null) {
+          throw new Error("failed to find base for pillage");
+        }
+
+        debugAction($, {
+          type: "RESOLVE_EFFECT",
+          effect: eid,
+          params: {
+            target: base.id,
+          },
+        });
+      };
+
       it("can't steal more gold than the target has", () => {
-        expect(true).to.equal(false);
+        P.gold = 0;
+        oppP.gold = 0;
+        playAndResolvePillage(oppP.id);
+        expect(P.gold).to.equal(0);
+        expect(oppP.gold).to.equal(0);
+
+        P.gold = 0;
+        oppP.gold = 1;
+        playAndResolvePillage(oppP.id);
+        expect(P.gold).to.equal(1);
+        expect(oppP.gold).to.equal(0);
+
+        const EX_PIRATE_CARD = $.data.lookupCard("Bombaster");
+        createInstance($, P, EX_PIRATE_CARD);
+
+        P.gold = 0;
+        oppP.gold = 1;
+        playAndResolvePillage(oppP.id);
+        expect(P.gold).to.equal(1);
+        expect(oppP.gold).to.equal(0);
+
+        P.gold = 0;
+        oppP.gold = 2;
+        playAndResolvePillage(oppP.id);
+        expect(P.gold).to.equal(2);
+        expect(oppP.gold).to.equal(0);
+
+        P.gold = 0;
+        oppP.gold = 3;
+        playAndResolvePillage(oppP.id);
+        expect(P.gold).to.equal(2);
+        expect(oppP.gold).to.equal(1);
       });
     });
   });

--- a/src/tests/units/red.ts
+++ b/src/tests/units/red.ts
@@ -1,0 +1,8 @@
+describe("units", () => {
+  describe("red", () => {
+    describe("Bloodrage Ogre", () => {
+      it.skip("returns AFTER the draw/discard phase");
+      it.skip("only returns on its controller's turn");
+    });
+  });
+});

--- a/src/tests/units/red.ts
+++ b/src/tests/units/red.ts
@@ -1,8 +1,15 @@
+import { expect } from "chai";
+
 describe("units", () => {
   describe("red", () => {
     describe("Bloodrage Ogre", () => {
-      it.skip("returns AFTER the draw/discard phase");
-      it.skip("only returns on its controller's turn");
+      it("returns AFTER the draw/discard phase", () => {
+        expect(true).to.equal(false);
+      });
+
+      it("only returns on its controller's turn", () => {
+        expect(true).to.equal(false);
+      });
     });
   });
 });

--- a/src/tests/units/red.ts
+++ b/src/tests/units/red.ts
@@ -1,14 +1,64 @@
 import { expect } from "chai";
 
+import { GameEngine } from "../../framework/engine";
+import { createInstance } from "../../framework/mutators";
+import { InstanceState, PlayerState } from "../../framework/types";
+import { requireActivePlayer } from "../../game/helpers";
+
+import {
+  P1,
+  P2,
+  debugGotoNextTurn,
+  makeDefaultGame,
+} from "../testhelper";
+
+const inPlay = (
+  $: GameEngine,
+  I: InstanceState,
+): boolean => {
+  return $.getInstance(I.id) === I;
+};
+
 describe("units", () => {
   describe("red", () => {
+    let $: GameEngine;
+    let P: PlayerState;
+
+    beforeEach(() => {
+      $ = makeDefaultGame();
+      P = requireActivePlayer($);
+    });
+
     describe("Bloodrage Ogre", () => {
+      let I: InstanceState;
+
+      beforeEach(() => {
+        I = createInstance($, P, $.data.lookupCard("Bloodrage Ogre"));
+      });
+
       it("returns AFTER the draw/discard phase", () => {
-        expect(true).to.equal(false);
+        I.arrivalFatigue = false;
+
+        debugGotoNextTurn($, P2);
+        expect(inPlay($, I)).to.equal(false);
+        expect(P.hand.length).to.equal(6);
+        expect(P.deck.length).to.equal(0);
+        expect(P.discard.length).to.equal(5);
+        expect(P.hand.includes("Bloodrage Ogre")).to.equal(true);
       });
 
       it("only returns on its controller's turn", () => {
-        expect(true).to.equal(false);
+        debugGotoNextTurn($, P2);
+        expect(inPlay($, I)).to.equal(true);
+
+        I.arrivalFatigue = false;
+        I.owner = P2;
+
+        debugGotoNextTurn($, P1);
+        expect(inPlay($, I)).to.equal(true);
+
+        debugGotoNextTurn($, P2);
+        expect(inPlay($, I)).to.equal(false);
       });
     });
   });

--- a/src/tests/upgrades/red.ts
+++ b/src/tests/upgrades/red.ts
@@ -1,11 +1,56 @@
 import { expect } from "chai";
 
+import { GameEngine } from "../../framework/engine";
+import { createInstance } from "../../framework/mutators";
+import { InstanceState, PlayerState } from "../../framework/types";
+import { requireActivePlayer } from "../../game/helpers";
+
+import {
+  debugAction,
+  debugGotoNextTurn,
+  makeDefaultGame,
+} from "../testhelper";
+
 describe("upgrades", () => {
   describe("red", () => {
+    let $: GameEngine;
+    let P: PlayerState;
+
+    beforeEach(() => {
+      $ = makeDefaultGame();
+      P = requireActivePlayer($);
+    });
+
     describe("Bloodburn", () => {
+      let I: InstanceState;
+
+      beforeEach(() => {
+        I = createInstance($, P, $.data.lookupCard("Bloodburn"));
+      });
+
       it("can't be used on its first turn because it doesn't have " +
         "haste", () => {
-        expect(true).to.equal(false);
+        expect(I.arrivalFatigue).to.equal(true);
+
+        I.customRunes.BLOOD = 2;
+
+        expect(
+          () => debugAction($, {
+            type: "ACTIVATE_ABILITY",
+            instance: I.id,
+            ability: "Bloodburn #1",
+          }),
+        ).to.throw("instance cannot attack on the turn it arrived");
+
+        debugGotoNextTurn($, P.id);
+
+        expect(
+          () => debugAction($, {
+            type: "ACTIVATE_ABILITY",
+            instance: I.id,
+            ability: "Bloodburn #1",
+          }),
+        ).not.to.throw();
       });
     });
   });

--- a/src/tests/upgrades/red.ts
+++ b/src/tests/upgrades/red.ts
@@ -1,7 +1,12 @@
+import { expect } from "chai";
+
 describe("upgrades", () => {
   describe("red", () => {
     describe("Bloodburn", () => {
-      it.skip("can't be used on its first turn because it doesn't have haste");
+      it("can't be used on its first turn because it doesn't have " +
+        "haste", () => {
+        expect(true).to.equal(false);
+      });
     });
   });
 });

--- a/src/tests/upgrades/red.ts
+++ b/src/tests/upgrades/red.ts
@@ -1,0 +1,7 @@
+describe("upgrades", () => {
+  describe("red", () => {
+    describe("Bloodburn", () => {
+      it.skip("can't be used on its first turn because it doesn't have haste");
+    });
+  });
+});


### PR DESCRIPTION
- Impl for the 10 red starter cards (and tests for these cards' rulings)
- Expanded helpers for writing card abilities
- New effect chaining support, letting multiple effects trigger in sequence using the same params (this support is still somewhat rudimentary; Zane is refactored to use this instead of a dedicated `SHOVE` effect)

Ravings:

I'm beginning to rethink effect impl a bit. It might be more sensible to have queries / anything that needs player input totally separate from the rest of the effect impl (i.e., instead of the effect call saying "I need input from the player and this is exactly what it looks like", it says "I need to read this field from the player's input" and separately we have a query object that says "we need to get this input and store it in this field".

This would lead to duplication, but might dramatically simplify things esp in the case when multiple sub-effects need to use the same input (since they would all reference the same input field name, which would have a query defined in one clear place).

This still doesn't solve the problem of using output from one effect as input into another, though, which is sort of hacked in with `GET_CONTROLLER`. It also might make the frontend more complicated, because the implicitly freeform nature of inputs would mean we can't really know how to present this to the player (we lose context around "oh we're looking for an instance to do damage to").

This also all sort of points back to the discussion around CUSTOM events. The original idea was that custom events could handle this sort of thing, but it has never happened (because it's not elegant?), it has some problems (e.g. requires an instance to own it), and it feels like this just quickly would become "every effect in the game is a custom effect", which has the same problem of being super opaque for the frontend to deal with. I suppose in both cases the frontend can deal with uncertainty by making assumptions based on the `sourceCard`, but in that case we need to audit and make sure that only card effects set that field (and not engine effects, like combat damage)